### PR TITLE
Add more options for SVG conversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -42,21 +42,21 @@
       }
     },
     "ajv": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-      "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
@@ -220,6 +220,15 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -642,9 +651,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
     "doctrine": {
@@ -742,12 +751,12 @@
       }
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
+      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.4",
+        "ajv": "5.3.0",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
@@ -763,7 +772,7 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.6",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
@@ -784,23 +793,6 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "eslint-config-notninja": {
@@ -825,7 +817,7 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -883,7 +875,7 @@
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
+        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -930,6 +922,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1241,9 +1239,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
-      "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "image-size": {
@@ -1291,23 +1289,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "ip-regex": {
@@ -1524,9 +1505,9 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
       "dev": true
     },
     "json-schema": {
@@ -1783,12 +1764,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "natural-compare": {
@@ -2319,21 +2294,29 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
-      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.2.tgz",
+      "integrity": "sha512-4mUsjHfjrHyPFGDTtNJl0q8cv4VOJGvQykI1r3fnn05ys0sQL9M1Y+DyyGNWLD2PMcoyqjJ/nFDm4K54V1eQOg==",
       "dev": true,
       "requires": {
-        "diff": "3.2.0",
+        "diff": "3.4.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
         "lolex": "2.1.3",
-        "native-promise-only": "0.8.1",
         "nise": "1.2.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
-        "text-encoding": "0.6.4",
+        "supports-color": "4.5.0",
         "type-detect": "4.0.3"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "slice-ansi": {
@@ -2406,23 +2389,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "string_decoder": {
@@ -2439,12 +2405,20 @@
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {
@@ -2493,8 +2467,8 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.4",
-        "ajv-keywords": "2.1.0",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
         "slice-ansi": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -529,11 +529,15 @@
       }
     },
     "convert-svg-to-png": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/convert-svg-to-png/-/convert-svg-to-png-0.1.0.tgz",
-      "integrity": "sha512-5QPhvyeUpUsxasnONRFrpypB9duBI8XbYdDeLQH6tUw7v++n4OFu4NpRMj/ZKPoR9eFbTlF5e8m4xHDeFddEFw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/convert-svg-to-png/-/convert-svg-to-png-0.2.0.tgz",
+      "integrity": "sha512-/tj4R0uEq4chXHHwoL06O3Xd23s7SU/acYR4YOnI5MtdniS3sE2WfX2szOSyh+Lbh6agvzgRdQ8dxRKfVwn4vA==",
       "requires": {
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
         "file-url": "2.0.2",
+        "get-stdin": "5.0.1",
+        "glob": "7.1.2",
         "puppeteer": "0.12.0",
         "tmp": "0.0.33"
       }
@@ -1033,6 +1037,11 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
     },
     "get-stream": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
-    "eslint": "^4.9.0",
+    "eslint": "^4.10.0",
     "eslint-config-notninja": "^0.2.3",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",
-    "sinon": "^4.0.1"
+    "sinon": "^4.0.2"
   },
   "bin": {
     "brander": "bin/brander"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chalk": "^2.3.0",
     "color-convert": "^1.9.0",
     "commander": "^2.11.0",
-    "convert-svg-to-png": "^0.1.0",
+    "convert-svg-to-png": "^0.2.0",
     "debug": "^3.1.0",
     "glob": "^7.1.2",
     "hosted-git-info": "github:neocotic/hosted-git-info#browsefile",

--- a/src/task/convert/convert-svg-to-ico-task.js
+++ b/src/task/convert/convert-svg-to-ico-task.js
@@ -100,10 +100,15 @@ class ConvertSVGToICOTask extends Task {
   }
 
   async [_execute](inputFile, size, context) {
+    const scale = context.option('scale');
     const inputFilePath = inputFile.absolute;
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.ico', inputFile.format)
-      .evaluate({ file: inputFile, size });
+      .evaluate({
+        file: inputFile,
+        scale,
+        size
+      });
     const outputFilePath = outputFile.absolute;
 
     debug('Reading SVG file to be converted to ICO: %s', chalk.blue(inputFilePath));
@@ -115,6 +120,7 @@ class ConvertSVGToICOTask extends Task {
     const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
       baseFile: inputFilePath,
       height: size.height,
+      scale,
       width: size.width
     } : null));
 

--- a/src/task/convert/convert-svg-to-ico-task.js
+++ b/src/task/convert/convert-svg-to-ico-task.js
@@ -100,11 +100,15 @@ class ConvertSVGToICOTask extends Task {
   }
 
   async [_execute](inputFile, size, context) {
-    const scale = context.option('scale');
     const inputFilePath = inputFile.absolute;
+    const baseUrl = context.option('baseUrl');
+    const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
+    const scale = context.option('scale');
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.ico', inputFile.format)
       .evaluate({
+        baseFile,
+        baseUrl,
         file: inputFile,
         scale,
         size
@@ -118,7 +122,8 @@ class ConvertSVGToICOTask extends Task {
     debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
     const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
-      baseFile: inputFilePath,
+      baseFile,
+      baseUrl,
       height: size.height,
       scale,
       width: size.width

--- a/src/task/convert/convert-svg-to-png-task.js
+++ b/src/task/convert/convert-svg-to-png-task.js
@@ -94,11 +94,15 @@ class ConvertSVGToPNGTask extends Task {
   }
 
   async [_execute](inputFile, size, context) {
-    const scale = context.option('scale');
     const inputFilePath = inputFile.absolute;
+    const baseUrl = context.option('baseUrl');
+    const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
+    const scale = context.option('scale');
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.png', inputFile.format)
       .evaluate({
+        baseFile,
+        baseUrl,
         file: inputFile,
         scale,
         size
@@ -112,7 +116,8 @@ class ConvertSVGToPNGTask extends Task {
     debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
     const output = await this[_converter].convert(input, Object.assign(size ? {
-      baseFile: inputFilePath,
+      baseFile,
+      baseUrl,
       height: size.height,
       scale,
       width: size.width

--- a/src/task/convert/convert-svg-to-png-task.js
+++ b/src/task/convert/convert-svg-to-png-task.js
@@ -94,10 +94,15 @@ class ConvertSVGToPNGTask extends Task {
   }
 
   async [_execute](inputFile, size, context) {
+    const scale = context.option('scale');
     const inputFilePath = inputFile.absolute;
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.png', inputFile.format)
-      .evaluate({ file: inputFile, size });
+      .evaluate({
+        file: inputFile,
+        scale,
+        size
+      });
     const outputFilePath = outputFile.absolute;
 
     debug('Reading SVG file to be converted to PNG: %s', chalk.blue(inputFilePath));
@@ -109,6 +114,7 @@ class ConvertSVGToPNGTask extends Task {
     const output = await this[_converter].convert(input, Object.assign(size ? {
       baseFile: inputFilePath,
       height: size.height,
+      scale,
       width: size.width
     } : null));
 

--- a/src/task/package/package-svg-to-ico-task.js
+++ b/src/task/package/package-svg-to-ico-task.js
@@ -114,11 +114,13 @@ class PackageSVGToICOTask extends Task {
 
   async [_readData](inputFiles, context) {
     const inputs = [];
+    const baseUrl = context.option('baseUrl');
     const scale = context.option('scale');
     const sizes = context.option('sizes');
 
     for (const inputFile of inputFiles) {
       const inputFilePath = inputFile.absolute;
+      const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
       const size = _.nth(sizes, inputs.length);
 
       debug('Reading SVG file to be packaged in ICO: %s', chalk.blue(inputFilePath));
@@ -128,7 +130,8 @@ class PackageSVGToICOTask extends Task {
       debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
       const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
-        baseFile: inputFilePath,
+        baseFile,
+        baseUrl,
         height: size.height,
         scale,
         width: size.width

--- a/src/task/package/package-svg-to-ico-task.js
+++ b/src/task/package/package-svg-to-ico-task.js
@@ -114,6 +114,7 @@ class PackageSVGToICOTask extends Task {
 
   async [_readData](inputFiles, context) {
     const inputs = [];
+    const scale = context.option('scale');
     const sizes = context.option('sizes');
 
     for (const inputFile of inputFiles) {
@@ -129,11 +130,15 @@ class PackageSVGToICOTask extends Task {
       const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
         baseFile: inputFilePath,
         height: size.height,
+        scale,
         width: size.width
       } : null));
       const [ realSize ] = await Size.fromImage(pngInput);
 
-      inputs.push({ input: pngInput, size: realSize });
+      inputs.push({
+        input: pngInput,
+        size: realSize
+      });
     }
 
     return inputs;


### PR DESCRIPTION
This PR implements the changes requested for #10 and #11.

All tasks that accept SVG as an (explicit) input now also accept the following additional options:

* baseFile
* baseUrl
* scale

To reiterate what was mentioned in #11; you cannot use both `baseFile` and `baseUrl` at the same time for a single task.