### PR TITLE
Add background option for SVG conversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -528,18 +528,27 @@
         "typedarray": "0.0.6"
       }
     },
-    "convert-svg-to-png": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/convert-svg-to-png/-/convert-svg-to-png-0.2.0.tgz",
-      "integrity": "sha512-/tj4R0uEq4chXHHwoL06O3Xd23s7SU/acYR4YOnI5MtdniS3sE2WfX2szOSyh+Lbh6agvzgRdQ8dxRKfVwn4vA==",
+    "convert-svg-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-svg-core/-/convert-svg-core-0.3.0.tgz",
+      "integrity": "sha512-pcNVB+N4COFl3xqS8mrRP2PbqOmY012WkqprxQD9XVGHOY0mJANItjvVf7A4Vy4vpPQDRStyF+xMqvidoF1/qA==",
       "requires": {
         "chalk": "2.3.0",
         "commander": "2.11.0",
         "file-url": "2.0.2",
         "get-stdin": "5.0.1",
         "glob": "7.1.2",
+        "pollock": "0.1.0",
         "puppeteer": "0.12.0",
         "tmp": "0.0.33"
+      }
+    },
+    "convert-svg-to-png": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-svg-to-png/-/convert-svg-to-png-0.3.0.tgz",
+      "integrity": "sha512-oTjKkkCE1Ywl7WJU5cKQfXDAo09nsQLgUaSnasiqdTFluBkm7YSJFfCEQaf2lMPPFhABNTXmvsyWu+rFH24Y8A==",
+      "requires": {
+        "convert-svg-core": "0.3.0"
       }
     },
     "core-util-is": {
@@ -884,22 +893,22 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
         "mkdirp": {
@@ -909,11 +918,6 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
     },
@@ -2079,7 +2083,7 @@
       "integrity": "sha512-H/bylN7FccwbN7JZoSP+xRozxgJEDNy4uC4p727cyttKUVNXYjFuEMueJYHW0pblnrfLEH341SyFJVWhJMLxKQ==",
       "requires": {
         "debug": "2.6.9",
-        "extract-zip": "1.6.5",
+        "extract-zip": "1.6.6",
         "https-proxy-agent": "2.1.0",
         "mime": "1.4.1",
         "progress": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chalk": "^2.3.0",
     "color-convert": "^1.9.0",
     "commander": "^2.11.0",
-    "convert-svg-to-png": "^0.2.0",
+    "convert-svg-to-png": "^0.3.0",
     "debug": "^3.1.0",
     "glob": "^7.1.2",
     "hosted-git-info": "github:neocotic/hosted-git-info#browsefile",

--- a/src/task/convert/convert-svg-to-ico-task.js
+++ b/src/task/convert/convert-svg-to-ico-task.js
@@ -101,12 +101,14 @@ class ConvertSVGToICOTask extends Task {
 
   async [_execute](inputFile, size, context) {
     const inputFilePath = inputFile.absolute;
+    const background = context.option('background');
     const baseUrl = context.option('baseUrl');
     const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
     const scale = context.option('scale');
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.ico', inputFile.format)
       .evaluate({
+        background,
         baseFile,
         baseUrl,
         file: inputFile,
@@ -121,13 +123,15 @@ class ConvertSVGToICOTask extends Task {
 
     debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
-    const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
+    const pngInput = await this[_converter].convert(svgInput, Object.assign({
+      background,
       baseFile,
       baseUrl,
+      scale
+    }, !size ? null : {
       height: size.height,
-      scale,
       width: size.width
-    } : null));
+    }));
 
     debug('Converting PNG to ICO');
 

--- a/src/task/convert/convert-svg-to-png-task.js
+++ b/src/task/convert/convert-svg-to-png-task.js
@@ -95,12 +95,14 @@ class ConvertSVGToPNGTask extends Task {
 
   async [_execute](inputFile, size, context) {
     const inputFilePath = inputFile.absolute;
+    const background = context.option('background');
     const baseUrl = context.option('baseUrl');
     const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
     const scale = context.option('scale');
     const outputFile = context.outputFile
       .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.png', inputFile.format)
       .evaluate({
+        background,
         baseFile,
         baseUrl,
         file: inputFile,
@@ -115,13 +117,15 @@ class ConvertSVGToPNGTask extends Task {
 
     debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
-    const output = await this[_converter].convert(input, Object.assign(size ? {
+    const output = await this[_converter].convert(input, Object.assign({
+      background,
       baseFile,
       baseUrl,
+      scale
+    }, !size ? null : {
       height: size.height,
-      scale,
       width: size.width
-    } : null));
+    }));
 
     debug('Writing converted PNG file: %s', chalk.blue(outputFilePath));
 

--- a/src/task/package/package-svg-to-ico-task.js
+++ b/src/task/package/package-svg-to-ico-task.js
@@ -114,6 +114,7 @@ class PackageSVGToICOTask extends Task {
 
   async [_readData](inputFiles, context) {
     const inputs = [];
+    const background = context.option('background');
     const baseUrl = context.option('baseUrl');
     const scale = context.option('scale');
     const sizes = context.option('sizes');
@@ -129,13 +130,15 @@ class PackageSVGToICOTask extends Task {
 
       debug('Converting SVG file to PNG: %s', chalk.blue(inputFilePath));
 
-      const pngInput = await this[_converter].convert(svgInput, Object.assign(size ? {
+      const pngInput = await this[_converter].convert(svgInput, Object.assign({
+        background,
         baseFile,
         baseUrl,
+        scale
+      }, !size ? null : {
         height: size.height,
-        scale,
         width: size.width
-      } : null));
+      }));
       const [ realSize ] = await Size.fromImage(pngInput);
 
       inputs.push({


### PR DESCRIPTION
All tasks that accept SVG as an (explicit) input now also accept an additional `background` option, taking advantage of NotNinja/convert-svg#14.