### PR TITLE
Add task to convert an SVG file to JPEG files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -543,6 +543,14 @@
         "tmp": "0.0.33"
       }
     },
+    "convert-svg-to-jpeg": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/convert-svg-to-jpeg/-/convert-svg-to-jpeg-0.3.0.tgz",
+      "integrity": "sha512-lbx6RphsI3/caVi0M5WmaKaFsxvRGB6oMrp2om9ieilzUaGj7K/Ga4H8RxVKlea+neEBDtcP5Le7z+/tz1d6eQ==",
+      "requires": {
+        "convert-svg-core": "0.3.0"
+      }
+    },
     "convert-svg-to-png": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/convert-svg-to-png/-/convert-svg-to-png-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^2.3.0",
     "color-convert": "^1.9.0",
     "commander": "^2.11.0",
+    "convert-svg-to-jpeg": "^0.3.0",
     "convert-svg-to-png": "^0.3.0",
     "debug": "^3.1.0",
     "glob": "^7.1.2",

--- a/src/task/convert/convert-svg-to-jpeg-task.js
+++ b/src/task/convert/convert-svg-to-jpeg-task.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, !ninja
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const chalk = require('chalk');
+const { createConverter } = require('convert-svg-to-jpeg');
+const debug = require('debug')('brander:task:convert');
+
+const File = require('../../file');
+const Task = require('../task');
+const TaskType = require('../task-type');
+
+const _converter = Symbol('converter');
+const _execute = Symbol('execute');
+
+/**
+ * A {@link TaskType.CONVERT} task that can convert a SVG file to potentially multiple JPEG files, if multiple
+ * <code>sizes</code> are specified in the options.
+ *
+ * @public
+ */
+class ConvertSVGToJPEGTask extends Task {
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  beforeAll(config) {
+    this[_converter] = createConverter();
+  }
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  async afterAll(config) {
+    await this[_converter].destroy();
+    delete this[_converter];
+  }
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  getType() {
+    return TaskType.CONVERT;
+  }
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  async execute(context) {
+    const sizes = context.option('sizes');
+
+    for (const inputFile of context.inputFiles) {
+      if (_.isEmpty(sizes)) {
+        await this[_execute](inputFile, null, context);
+      } else {
+        for (const size of sizes) {
+          await this[_execute](inputFile, size, context);
+        }
+      }
+    }
+  }
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  supports(context) {
+    return _.every(context.inputFiles, _.matchesProperty('format', 'svg')) && context.outputFile.format === 'jpeg';
+  }
+
+  async [_execute](inputFile, size, context) {
+    const inputFilePath = inputFile.absolute;
+    const background = context.option('background');
+    const baseUrl = context.option('baseUrl');
+    const baseFile = context.option('baseFile') || !baseUrl ? inputFilePath : null;
+    const quality = context.option('quality');
+    const scale = context.option('scale');
+    const outputFile = context.outputFile
+      .defaults(inputFile.dir, '<%= file.base(true) %><%= size ? "-" + size : "" %>.jpeg', inputFile.format)
+      .evaluate({
+        background,
+        baseFile,
+        baseUrl,
+        file: inputFile,
+        quality,
+        scale,
+        size
+      });
+    const outputFilePath = outputFile.absolute;
+
+    debug('Reading SVG file to be converted to JPEG: %s', chalk.blue(inputFilePath));
+
+    const input = await File.readFile(inputFilePath);
+
+    debug('Converting SVG file to JPEG: %s', chalk.blue(inputFilePath));
+
+    const output = await this[_converter].convert(input, Object.assign({
+      background,
+      baseFile,
+      baseUrl,
+      quality,
+      scale
+    }, !size ? null : {
+      height: size.height,
+      width: size.width
+    }));
+
+    debug('Writing converted JPEG file: %s', chalk.blue(outputFilePath));
+
+    await File.writeFile(outputFilePath, output);
+
+    context.config.logger.log('Converted SVG file to JPEG file: %s -> %s', chalk.blue(inputFile.relative),
+      chalk.blue(outputFile.relative));
+  }
+
+}
+
+module.exports = ConvertSVGToJPEGTask;


### PR DESCRIPTION
This PR takes advantage of NotNinja/convert-svg#18 and adds a new task for converting an SVG file to one or more JPEG files. This task acts almost identically to the `convert-svg-to-png-task` except that it outputs JPEG files and supports an additional `quality` option to support JPEG output quality. This option must be between 0-100 (inclusive) with 100 being the default.