### PR TITLE
Use hosted-git-info@^2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "convert-svg-to-png": "^0.4.0",
     "debug": "^3.1.0",
     "glob": "^7.1.2",
-    "hosted-git-info": "github:neocotic/hosted-git-info#browsefile",
+    "hosted-git-info": "^2.6.0",
     "image-size": "^0.6.2",
     "lodash": "^4.17.5",
     "mime": "^2.2.0",


### PR DESCRIPTION
For a some time we've had to use my personal branch of `hosted-git-info` while we waited for a PR containing a feature required by Brander to be merged and released. This has now happened so I'd like to switch to v2.6.0, which contains these changes.